### PR TITLE
Destructive & disabled items

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,11 @@ Optional. The title above the popup menu.
 
 ###### `actions`
 
-Array of `{ title?: string, systemIcon?: string }`. System icon refers to an icon name within [SF Symbols](https://developer.apple.com/design/human-interface-guidelines/sf-symbols/overview/).
+Array of `{ title: string, systemIcon?: string, destructive?: boolean, disabled?: boolean }`.
+
+System icon refers to an icon name within [SF Symbols](https://developer.apple.com/design/human-interface-guidelines/sf-symbols/overview/).
+
+Destructive items are rendered in red on iOS, and unchanged on Android.
 
 ###### `onPress`
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ const Example = () => {
         );
       }}
     >
-      <View style={styles.yourOwnStyles}>
+      <View style={styles.yourOwnStyles} />
     </ContextMenu>
   );
 };

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # react-native-context-menu-view
 
-Use native context menu functionality from React Native. On iOS this uses `UIMenu` functionality, and on Android it uses a `PopUpMenu`.
+Use native context menu functionality from React Native. On iOS 13+ this uses `UIMenu` functionality, and on Android it uses a `PopUpMenu`.
+
+On iOS 12 and below, nothing happens. You may wish to do a `Platform.OS === 'ios' && parseInt(Platform.Version, 10) < 12` check, and add your own `onLongPress` handler.
 
 <img src="./assets/context-menu-ios.gif" width="300">
 
@@ -12,14 +14,46 @@ Use native context menu functionality from React Native. On iOS this uses `UIMen
 
 ```bash
 cd ios/
-pod install 
+pod install
 ```
 
 ## Usage
+
 ```javascript
-import ContextMenu from 'react-native-context-menu-view';
+import ContextMenu from "react-native-context-menu-view";
+
+const Example = () => {
+  return (
+    <ContextMenu
+      actions={[{ title: "Title 1" }, { title: "Title 2" }]}
+      onPress={(e) => {
+        console.warn(
+          `Pressed ${e.nativeEvent.name} at index ${e.nativeEvent.index}`
+        );
+      }}
+    >
+      <View style={styles.yourOwnStyles}>
+    </ContextMenu>
+  );
+};
 ```
 
-More coming soon. 
+See `example/` for basic usage.
 
-See `example/` for basic usage. 
+## Props
+
+###### `title`
+
+Optional. The title above the popup menu.
+
+###### `actions`
+
+Array of `{ title?: string, systemIcon?: string }`. System icon refers to an icon name within [SF Symbols](https://developer.apple.com/design/human-interface-guidelines/sf-symbols/overview/).
+
+###### `onPress`
+
+Optional. When the popup is opened and the user picks an option. Called with `{ nativeEvent: { index, name } }`.
+
+###### `onCancel`
+
+Optional. When the popop is opened and the user cancels.

--- a/android/src/main/java/com/mpiannucci/reactnativecontextmenu/ContextMenuManager.java
+++ b/android/src/main/java/com/mpiannucci/reactnativecontextmenu/ContextMenuManager.java
@@ -37,14 +37,7 @@ public class ContextMenuManager extends ViewGroupManager<ContextMenuView> {
 
     @ReactProp(name = "actions")
     public void setActions(ContextMenuView view, @Nullable ReadableArray actions) {
-        ArrayList<String> newActions = new ArrayList();
-
-        for (int i = 0; i < actions.size(); i++) {
-            ReadableMap action = actions.getMap(i);
-            newActions.add(action.getString("title"));
-        }
-
-        view.setActions(newActions);
+        view.setActions(actions);
     }
 
     @androidx.annotation.Nullable

--- a/android/src/main/java/com/mpiannucci/reactnativecontextmenu/ContextMenuView.java
+++ b/android/src/main/java/com/mpiannucci/reactnativecontextmenu/ContextMenuView.java
@@ -14,6 +14,8 @@ import android.widget.PopupMenu;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.touch.OnInterceptTouchEventListener;
 import com.facebook.react.uimanager.events.RCTEventEmitter;
@@ -21,7 +23,19 @@ import com.facebook.react.views.view.ReactViewGroup;
 
 import java.util.List;
 
+import javax.annotation.Nullable;
+
 public class ContextMenuView extends ReactViewGroup implements PopupMenu.OnMenuItemClickListener, PopupMenu.OnDismissListener {
+
+    public class Action {
+        String title;
+        boolean disabled;
+
+        public Action(String title, boolean disabled) {
+            this.title = title;
+            this.disabled = disabled;
+        }
+    }
 
     PopupMenu contextMenu;
 
@@ -62,15 +76,15 @@ public class ContextMenuView extends ReactViewGroup implements PopupMenu.OnMenuI
         return false;
     }
 
-    public void setActions(List<String> actions) {
+    public void setActions(@Nullable ReadableArray actions) {
         Menu menu = contextMenu.getMenu();
         menu.clear();
 
-        int i = 0;
-        for (String action : actions) {
+        for (int i = 0; i < actions.size(); i++) {
+            ReadableMap action = actions.getMap(i);
             int order = i;
-            menu.add(Menu.NONE, Menu.NONE, order, action);
-            i += 1;
+            menu.add(Menu.NONE, Menu.NONE, order, action.getString("title"));
+            menu.getItem(i).setEnabled(!action.hasKey("disabled") || !action.getBoolean("disabled"));
         }
     }
 

--- a/android/src/main/java/com/mpiannucci/reactnativecontextmenu/ContextMenuView.java
+++ b/android/src/main/java/com/mpiannucci/reactnativecontextmenu/ContextMenuView.java
@@ -66,8 +66,11 @@ public class ContextMenuView extends ReactViewGroup implements PopupMenu.OnMenuI
         Menu menu = contextMenu.getMenu();
         menu.clear();
 
+        int i = 0;
         for (String action : actions) {
-            menu.add(action);
+            int order = i;
+            menu.add(Menu.NONE, Menu.NONE, order, action);
+            i += 1;
         }
     }
 
@@ -76,6 +79,7 @@ public class ContextMenuView extends ReactViewGroup implements PopupMenu.OnMenuI
         cancelled = false;
         ReactContext reactContext = (ReactContext) getContext();
         WritableMap event = Arguments.createMap();
+        event.putInt("index", menuItem.getOrder());
         event.putString("name", menuItem.getTitle().toString());
         reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "onPress", event);
         return false;

--- a/example/App.js
+++ b/example/App.js
@@ -10,12 +10,21 @@ const App = () => {
       <ContextMenu title={'Set Color'} actions={[
         {
           title: 'blue',
-          systemIcon: color == 'blue' ? 'paintbrush.fill' : 'paintbrush',
+          systemIcon: color === 'blue' ? 'paintbrush.fill' : 'paintbrush',
         },
         {
           title: 'red',
-          systemIcon: color == 'red' ? 'paintbrush.fill' : 'paintbrush'
-        }
+          systemIcon: color === 'red' ? 'paintbrush.fill' : 'paintbrush',
+        },
+        {
+          title: 'transparent',
+          systemIcon: 'trash',
+          destructive: true,
+        },
+        {
+          title: 'disabled item',
+          disabled: true,
+        },
       ]} onPress={(event) => {
         setColor(event.nativeEvent.name);
       }} onCancel={() => { console.warn('CANCELLED') }} >

--- a/index.d.ts
+++ b/index.d.ts
@@ -21,7 +21,7 @@ export interface ContextMenuProps {
 	/**
 	 * The title of the menu
 	 */
-	title?: string;
+	title: string;
 	/**
 	 * The actions to show the user when the menu is activated
 	 */

--- a/index.d.ts
+++ b/index.d.ts
@@ -12,6 +12,11 @@ export interface ContextMenuAction {
 	systemIcon?: string;
 }
 
+export interface ContextMenuOnPressNativeEvent {
+	index: number;
+	name: string;
+}
+
 export interface ContextMenuProps {
 	/**
 	 * The title of the menu
@@ -24,7 +29,7 @@ export interface ContextMenuProps {
 	/**
 	 * Handle when an action is triggered and the menu is closed. The name of the selected action will be passed in the event. 
 	 */
-	onPress?: (e: NativeSyntheticEvent<{name: string}>) => void;
+	onPress?: (e: NativeSyntheticEvent<ContextMenuOnPressNativeEvent>) => void;
 	/**
 	 * Handle when the menu is cancelled and closed
 	 */

--- a/ios/ContextMenuAction.h
+++ b/ios/ContextMenuAction.h
@@ -12,5 +12,7 @@
 
 @property (nonatomic, copy) NSString* title;
 @property (nonatomic, copy) NSString* systemIcon;
+@property (nonatomic, assign) BOOL destructive;
+@property (nonatomic, assign) BOOL disabled;
 
 @end

--- a/ios/ContextMenuView.m
+++ b/ios/ContextMenuView.m
@@ -54,6 +54,10 @@
         }
       }];
 
+      actionMenuItem.attributes =
+        (thisAction.destructive ? UIMenuElementAttributesDestructive : 0) |
+        (thisAction.disabled ? UIMenuElementAttributesDisabled : 0);
+
       [actions addObject:actionMenuItem];
     }];
                               

--- a/ios/ContextMenuView.m
+++ b/ios/ContextMenuView.m
@@ -43,16 +43,19 @@
   return [UIContextMenuConfiguration configurationWithIdentifier:nil previewProvider:nil actionProvider:^UIMenu * _Nullable(NSArray<UIMenuElement *> * _Nonnull suggestedActions) {
     NSMutableArray* actions = [[NSMutableArray alloc] init];
     
-    for (ContextMenuAction* thisAction in self.actions) {
+    [self.actions enumerateObjectsUsingBlock:^(ContextMenuAction* thisAction, NSUInteger idx, BOOL *stop) {
       UIAction* actionMenuItem = [UIAction actionWithTitle:thisAction.title.capitalizedString image:[UIImage systemImageNamed:thisAction.systemIcon] identifier:nil handler:^(__kindof UIAction * _Nonnull action) {
         if (self.onPress != nil) {
           self->cancelled = false;
-          self.onPress(@{@"name": thisAction.title});
+          self.onPress(@{
+            @"index": @(idx),
+            @"name": thisAction.title,
+          });
         }
       }];
-      
+
       [actions addObject:actionMenuItem];
-    }
+    }];
                               
     return [UIMenu menuWithTitle:self.title children:actions];
   }];

--- a/ios/RCTConvert+ContextMenuAction.m
+++ b/ios/RCTConvert+ContextMenuAction.m
@@ -15,6 +15,8 @@
     ContextMenuAction* action = [[ContextMenuAction alloc] init];
   action.title = [self NSString:json[@"title"]];
   action.systemIcon = [self NSString:json[@"systemIcon"]];
+  action.destructive = [self BOOL:json[@"destructive"]];
+  action.disabled = [self BOOL:json[@"disabled"]];
   return action;
 }
 


### PR DESCRIPTION
Builds on top of #4 so the diff looks a bit larger than the actual change for this

On Android, it looks like disabled items are interactive, but nothing happens when you press them. Not sure if there's any extra flags you gotta pass in to grey them out like iOS

![Simulator Screen Shot - iPhone SE (1st generation) - 2020-06-02 at 18 20 22](https://user-images.githubusercontent.com/7275322/83550750-3cafee80-a4ff-11ea-9bbe-aef1b67e9c99.png)
