### PR TITLE
android: fix LongPress detection

### DIFF
--- a/android/src/main/java/com/mpiannucci/reactnativecontextmenu/ContextMenuView.java
+++ b/android/src/main/java/com/mpiannucci/reactnativecontextmenu/ContextMenuView.java
@@ -73,7 +73,7 @@ public class ContextMenuView extends ReactViewGroup implements PopupMenu.OnMenuI
     @Override
     public boolean onTouchEvent(MotionEvent ev) {
         gestureDetector.onTouchEvent(ev);
-        return false;
+        return true;
     }
 
     public void setActions(@Nullable ReadableArray actions) {


### PR DESCRIPTION
Fix LongPress being accidentally fired for taps and scrolls.

The GestureDetector detects LongPress by processing ACTION_DOWN, setting a
timer to fire LongPress, then cancelling the timer upon receiving further
interaction events (eg ACTION_MOVE when scrolling is initiated, or ACTION_UP
when a finger is lifted, etc).

This changes ContextMenuView::onTouchEvent() to return true, as
false instructs the input system to stop forwarding successive events from the
current interaction, causing the GestureDetector to only see ACTION_DOWN events
and wrongly fire LongPress for every interaction.