### PR TITLE
feat: support android icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Array of `{ title: string, subtitle?: string, systemIcon?: string, destructive?:
 
 Subtitle is only available on iOS 15+.
 
-System icon refers to an icon name within [SF Symbols](https://developer.apple.com/design/human-interface-guidelines/sf-symbols/overview/).
+System icon refers to an icon name within [SF Symbols](https://developer.apple.com/design/human-interface-guidelines/sf-symbols/overview/) on IOS and Drawable name on Android.
 
 Destructive items are rendered in red on iOS, and unchanged on Android.
 

--- a/example/App.js
+++ b/example/App.js
@@ -1,6 +1,19 @@
 import React, { useState } from 'react';
-import { SafeAreaView, View, StyleSheet } from 'react-native';
+import { SafeAreaView, View, StyleSheet, Platform } from 'react-native';
 import ContextMenu from 'react-native-context-menu-view';
+
+const Icons = Platform.select({
+  ios: {
+    changeColor: 'paintbrush',
+    transparent: 'trash',
+    toggleCircle: 'circlebadge'
+  },
+  android: {
+    changeColor: 'baseline_format_paint',
+    transparent: 'baseline_delete',
+    toggleCircle: 'outline_circle',
+  }
+})
 
 const App = () => {
   const [color, setColor] = useState('blue');
@@ -11,7 +24,7 @@ const App = () => {
       <ContextMenu title={'Customize'} actions={[
         {
           title: 'Change Color',
-          systemIcon: 'paintbrush',
+          systemIcon: Icons.changeColor,
           inlineChildren: true,
           actions: [
             {
@@ -26,12 +39,12 @@ const App = () => {
         },
         {
           title: 'Transparent',
-          systemIcon: 'trash',
+          systemIcon: Icons.transparent,
           destructive: true,
         },
         {
           title: 'Toggle Circle',
-          systemIcon: 'circlebadge'
+          systemIcon: Icons.toggleCircle,
         },
         {
           title: 'Disabled Item',

--- a/example/android/app/src/main/res/drawable/baseline_delete.xml
+++ b/example/android/app/src/main/res/drawable/baseline_delete.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M6,19c0,1.1 0.9,2 2,2h8c1.1,0 2,-0.9 2,-2V7H6v12zM19,4h-3.5l-1,-1h-5l-1,1H5v2h14V4z"/>
+</vector>

--- a/example/android/app/src/main/res/drawable/baseline_format_paint.xml
+++ b/example/android/app/src/main/res/drawable/baseline_format_paint.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M18,4V3c0,-0.55 -0.45,-1 -1,-1H5c-0.55,0 -1,0.45 -1,1v4c0,0.55 0.45,1 1,1h12c0.55,0 1,-0.45 1,-1V6h1v4H9v11c0,0.55 0.45,1 1,1h2c0.55,0 1,-0.45 1,-1v-9h8V4h-3z"/>
+</vector>

--- a/example/android/app/src/main/res/drawable/outline_circle.xml
+++ b/example/android/app/src/main/res/drawable/outline_circle.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M12,2C6.47,2 2,6.47 2,12c0,5.53 4.47,10 10,10s10,-4.47 10,-10C22,6.47 17.53,2 12,2zM12,20c-4.42,0 -8,-3.58 -8,-8c0,-4.42 3.58,-8 8,-8s8,3.58 8,8C20,16.42 16.42,20 12,20z"/>
+</vector>

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,7 +11,7 @@ export interface ContextMenuAction {
 	 */
 	subtitle?: string;
 	/**
-	 * The icon to use on ios. This is the name of the SFSymbols icon to use. On Android nothing will happen if you set this option. 
+	 * The icon to use. This is the name of the SFSymbols icon to use on IOS and name of the Drawable to use on Android.
 	 */
 	systemIcon?: string;
 	/**


### PR DESCRIPTION
<img width="395" alt="image" src="https://github.com/mpiannucci/react-native-context-menu-view/assets/16725418/1fa29e06-3286-471d-9290-0f7c75fd3b5d">

Mentioned at #85, a little bit tricky way to show icon with plain `PopupMenu` that does not require any third party library.

Use reflection to access `MenuBilder`

> [!NOTE] 
> Implementation brings two warnings
> - `Accessing internal APIs via reflection is not supported and may not work on all devices or in the future`
> - `Reflective access to setOptionalIconsVisible, which is not part of the public SDK and therefore likely to change in future Android releases`