### PR TITLE
fix(android): menu shows when disabled set in some cases

### DIFF
--- a/android/src/main/java/com/mpiannucci/reactnativecontextmenu/ContextMenuView.java
+++ b/android/src/main/java/com/mpiannucci/reactnativecontextmenu/ContextMenuView.java
@@ -67,7 +67,7 @@ public class ContextMenuView extends ReactViewGroup implements PopupMenu.OnMenuI
         gestureDetector = new GestureDetector(context, new GestureDetector.SimpleOnGestureListener() {
             @Override
             public boolean onSingleTapConfirmed(MotionEvent e) {
-                if (dropdownMenuMode) {
+                if (dropdownMenuMode && !disabled) {
                     contextMenu.show();
                 }
                 return super.onSingleTapConfirmed(e);
@@ -75,7 +75,7 @@ public class ContextMenuView extends ReactViewGroup implements PopupMenu.OnMenuI
 
             @Override
             public void onLongPress(MotionEvent e) {
-                if (!dropdownMenuMode) {
+                if (!dropdownMenuMode && !disabled) {
                     contextMenu.show();
                 }
             }
@@ -106,8 +106,6 @@ public class ContextMenuView extends ReactViewGroup implements PopupMenu.OnMenuI
         }
         Menu menu = contextMenu.getMenu();
         menu.clear();
-
-        if (disabled) { return; }
 
         for (int i = 0; i < actions.size(); i++) {
             ReadableMap action = actions.getMap(i);


### PR DESCRIPTION
Not sure how to reproduce but I encountered it with a heavy component.

Change conditional expression to `GestureListener`