### PR TITLE
feat(android): support set icon color

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,13 @@ Optional. The title above the popup menu.
 
 ###### `actions`
 
-Array of `{ title: string, subtitle?: string, systemIcon?: string, destructive?: boolean, selected?: boolean, disabled?: boolean, disabled?: boolean, inlineChildren?: boolean, actions?: Array<ContextMenuAction> }`.
+Array of `{ title: string, subtitle?: string, systemIcon?: string, systemIconColor?: string, destructive?: boolean, selected?: boolean, disabled?: boolean, disabled?: boolean, inlineChildren?: boolean, actions?: Array<ContextMenuAction> }`.
 
 Subtitle is only available on iOS 15+.
 
 System icon refers to an icon name within [SF Symbols](https://developer.apple.com/design/human-interface-guidelines/sf-symbols/overview/) on IOS and Drawable name on Android.
+
+System icon color is only available on Android.
 
 Destructive items are rendered in red.
 

--- a/android/src/main/java/com/mpiannucci/reactnativecontextmenu/ContextMenuView.java
+++ b/android/src/main/java/com/mpiannucci/reactnativecontextmenu/ContextMenuView.java
@@ -114,6 +114,11 @@ public class ContextMenuView extends ReactViewGroup implements PopupMenu.OnMenuI
             int order = i;
             menu.add(Menu.NONE, Menu.NONE, order, title);
             menu.getItem(i).setEnabled(!action.hasKey("disabled") || !action.getBoolean("disabled"));
+
+            if (action.hasKey("systemIconColor") && systemIcon != null) {
+                int color = Color.parseColor(action.getString("systemIconColor"));
+                systemIcon.setTint(color);
+            }
             menu.getItem(i).setIcon(systemIcon);
             if (action.hasKey("destructive") && action.getBoolean("destructive")) {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {

--- a/index.d.ts
+++ b/index.d.ts
@@ -15,6 +15,10 @@ export interface ContextMenuAction {
 	 */
 	systemIcon?: string;
 	/**
+	 * Color of icon. (Android only)
+	 */
+  systemIconColor?: string;
+	/**
 	 * Destructive items are rendered in red on iOS, and unchanged on Android. (default: false)
 	 */
 	destructive?: boolean;


### PR DESCRIPTION
<img width="156" alt="image" src="https://github.com/mpiannucci/react-native-context-menu-view/assets/16725418/0fad1879-27f3-4fa1-8ea5-f09f5ed2c397">

Support change icon tint. Currently only available on android.