### PR TITLE
Switch Android ContextMenu Implementation

### DIFF
--- a/android/src/main/java/com/mpiannucci/reactnativecontextmenu/ContextMenuView.java
+++ b/android/src/main/java/com/mpiannucci/reactnativecontextmenu/ContextMenuView.java
@@ -109,6 +109,8 @@ public class ContextMenuView extends ReactViewGroup implements MenuItem.OnMenuIt
                 redTitle.setSpan(new ForegroundColorSpan(Color.RED), 0, title.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
                 contextMenu.getItem(i).setTitle(redTitle);
             }
+
+            contextMenu.getItem(i).setOnMenuItemClickListener(this);
         }
     }
 

--- a/example/App.js
+++ b/example/App.js
@@ -53,7 +53,6 @@ const App = () => {
         },
       ]} onPress={(event) => {
         const { index, indexPath, name } = event.nativeEvent;
-        console.log(indexPath);
         if (indexPath?.at(0) == 0) {
           // The first item is nested in a submenu
           setColor(name.toLowerCase());

--- a/example/App.js
+++ b/example/App.js
@@ -53,19 +53,10 @@ const App = () => {
         },
       ]} onPress={(event) => {
         const { index, indexPath, name } = event.nativeEvent;
+        console.log(indexPath);
         if (indexPath?.at(0) == 0) {
-          // On iOS the first item is nested in a submenu
+          // The first item is nested in a submenu
           setColor(name.toLowerCase());
-        } else if (name === 'Change Color') {
-          // On Android the first item is simply a change color
-          // button because nested menus are not supported
-          if (color === 'transparent') {
-            setColor(previousColor);
-          } else if (color === 'blue') {
-            setColor('red');
-          } else if (color === 'red') {
-            setColor('blue');
-          }
         } else if (index == 1) {
           if (color !== 'transparent') {
             setPreviousColor(color);

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,92 +1,92 @@
-import React, { Component } from 'react';
-import { NativeSyntheticEvent, ViewProps, ViewStyle } from 'react-native';
+import React, { Component } from "react";
+import { NativeSyntheticEvent, ViewProps, ViewStyle } from "react-native";
 
 export interface ContextMenuAction {
-	/**
-	 * The title of the action
-	 */
-	title: string;
-	/**
-	 * The subtitle of the action. iOS 15+.
-	 */
-	subtitle?: string;
-	/**
-	 * The icon to use. This is the name of the SFSymbols icon to use on IOS and name of the Drawable to use on Android.
-	 */
-	systemIcon?: string;
-	/**
-	 * Color of icon. (Android only)
-	 */
+  /**
+   * The title of the action
+   */
+  title: string;
+  /**
+   * The subtitle of the action. iOS 15+.
+   */
+  subtitle?: string;
+  /**
+   * The icon to use. This is the name of the SFSymbols icon to use on IOS and name of the Drawable to use on Android.
+   */
+  systemIcon?: string;
+  /**
+   * Color of icon. (Android only)
+   */
   systemIconColor?: string;
-	/**
-	 * Destructive items are rendered in red on iOS, and unchanged on Android. (default: false)
-	 */
-	destructive?: boolean;
-	/**
-	 * Selected items have a checkmark next to them on iOS, and unchanged on Android. (default: false)
-	 */
-	selected?: boolean;
-	/**
-	* Whether the action is disabled or not (default: false)
-	*/
-	disabled?: boolean;
-	/**
-	 * Whether its children (if any) should be rendered inline instead of in their own child menu (default: false, iOS only)
-	 */
-	inlineChildren?: boolean;
-	/**
-	 * Child actions. When child actions are supplied, the childs callback will contain its name but the same index as the topmost parent menu/action index. (iOS Only)
-	 */
-	actions?: Array<ContextMenuAction>;
+  /**
+   * Destructive items are rendered in red on iOS, and unchanged on Android. (default: false)
+   */
+  destructive?: boolean;
+  /**
+   * Selected items have a checkmark next to them on iOS, and unchanged on Android. (default: false)
+   */
+  selected?: boolean;
+  /**
+   * Whether the action is disabled or not (default: false)
+   */
+  disabled?: boolean;
+  /**
+   * Whether its children (if any) should be rendered inline instead of in their own child menu (default: false, iOS only)
+   */
+  inlineChildren?: boolean;
+  /**
+   * Child actions. When child actions are supplied, the childs callback will contain its name but the same index as the topmost parent menu/action index
+   */
+  actions?: Array<ContextMenuAction>;
 }
 
 export interface ContextMenuOnPressNativeEvent {
-	index: number;
-	indexPath: number[],
-	name: string;
+  index: number;
+  indexPath: number[];
+  name: string;
 }
 
 export interface ContextMenuProps extends ViewProps {
-	/**
-	 * The title of the menu
-	 */
-	title?: string;
-	/**
-	 * The actions to show the user when the menu is activated
-	 */
-	actions?: Array<ContextMenuAction>;
-	/**
-	 * Handle when an action is triggered and the menu is closed. The name of the selected action will be passed in the event. 
-	 */
-	onPress?: (e: NativeSyntheticEvent<ContextMenuOnPressNativeEvent>) => void;
-	/**
-	 * Handle when the preview is tapped. iOS only.
-	 */
-	onPreviewPress?: () => void;
-	/**
-	 * Handle when the menu is cancelled and closed
-	 */
-	onCancel?: () => void;
-	/**
-	 * The background color of the preview. This is displayed underneath your view. Set this to transparent (or another color) if the default causes issues.
-	 */
-	previewBackgroundColor?: ViewStyle["backgroundColor"];
-	/**
-	 * Custom preview component.
-	 */
-	preview?: React.ReactNode;
-	/**
-	 * When enabled, uses iOS 14 menu mode, and shows the context menu on a single tap with no zoomed preview.
-	 */
-	dropdownMenuMode?: boolean;
-	/**
-	 * Disable menu interaction
-	 */
-	disabled?: boolean;
-	/**
-	 * Children prop as per upgrade docs: https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#updates-to-typescript-definitions
-	 */
-	 children?: React.ReactNode;
+  /**
+   * The title of the menu
+   */
+  title?: string;
+  /**
+   * The actions to show the user when the menu is activated
+   */
+  actions?: Array<ContextMenuAction>;
+  /**
+   * Handle when an action is triggered and the menu is closed. The name of the selected action will be passed in the event.
+   */
+  onPress?: (e: NativeSyntheticEvent<ContextMenuOnPressNativeEvent>) => void;
+  /**
+   * Handle when the preview is tapped. iOS only.
+   */
+  onPreviewPress?: () => void;
+  /**
+   * Handle when the menu is cancelled and closed
+   */
+  onCancel?: () => void;
+  /**
+   * The background color of the preview. This is displayed underneath your view. Set this to transparent (or another color) if the default causes issues.
+   */
+  previewBackgroundColor?: ViewStyle["backgroundColor"];
+  /**
+   * Custom preview component.
+   */
+  preview?: React.ReactNode;
+  /**
+   * When enabled, uses iOS 14 menu mode, and shows the context menu on a single tap with no zoomed preview.
+   */
+  dropdownMenuMode?: boolean;
+  /**
+   * Disable menu interaction
+   */
+  disabled?: boolean;
+  /**
+   * Children prop as per upgrade docs: https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#updates-to-typescript-definitions
+   */
+  children?: React.ReactNode;
 }
 
-export default class ContextMenu extends Component<ContextMenuProps> { }
+export default class ContextMenu extends Component<ContextMenuProps> {}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-context-menu-view",
   "title": "React Native Context Menu View",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "description": "Use native context menu views from React Native",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
This PR switches to use the [native Android ContextMenu](#106 )

Changes: 
* ContextMenu will now show where the user clicks, consistent with android native functionality
* Nested Items are now supported on Android, the same as iOS

Breaking:
* This may break icon functionality on android because I don't believe android ContextMenu's can have icons. @VidocqH can you test or chime in here before i merge this? 

