### PR TITLE
Fix context menu popping up in lists on Android

### DIFF
--- a/android/src/main/java/com/mpiannucci/reactnativecontextmenu/ContextMenuView.java
+++ b/android/src/main/java/com/mpiannucci/reactnativecontextmenu/ContextMenuView.java
@@ -37,6 +37,8 @@ public class ContextMenuView extends ReactViewGroup implements View.OnCreateCont
 
     boolean cancelled = true;
 
+    int[] longPressStartLocation = new int[2];
+
     protected boolean dropdownMenuMode = false;
 
     protected boolean disabled = false;
@@ -61,11 +63,31 @@ public class ContextMenuView extends ReactViewGroup implements View.OnCreateCont
 
             @Override
             public void onLongPress(MotionEvent e) {
+                int[] location = new int[2];
+                getLocationOnScreen(location);
+
+                int dx = location[0] - longPressStartLocation[0];
+                int dy = location[1] - longPressStartLocation[1];
+                double distance = Math.sqrt(dx * dx + dy * dy);
+                // Cancel long press if the user moves their finger more than 10 pixels
+                // (e.g. the context menu is used inside the scrollable component and it
+                // moves as the user scrolls)
+                if (distance > 10) {
+                    cancelled = true;
+                    return;
+                }
+
                 if (!dropdownMenuMode && !disabled) {
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
                         showContextMenu(e.getX(), e.getY());
                     }
                 }
+            }
+
+            @Override
+            public boolean onDown(MotionEvent e) {
+                getLocationOnScreen(longPressStartLocation);
+                return super.onDown(e);
             }
         });
     }


### PR DESCRIPTION
## Description

This PR fixes the issue we noticed in our app. When list items rendered in the bottom sheet are wrapped with the `ContextMenuView` component, the context menu was popping up while the list was scrolled. The problem is likely caused by the fact that the [@gorhom/bottom-sheet](https://github.com/gorhom/react-native-bottom-sheet) library uses the [react-native-gesture-handler](https://github.com/software-mansion/react-native-gesture-handler), which somehow interferes with the native gesture handler. As a result, the Android's gesture detector didn't recognize the scroll event, and thus, the long press wasn't cancelled.

## Screen capture

| Before | After |
|-|-|
| <video src="https://github.com/mpiannucci/react-native-context-menu-view/assets/52978053/b5d5b95d-ccc5-4373-81a4-74ae9e87eaba" /> | <video src="https://github.com/mpiannucci/react-native-context-menu-view/assets/52978053/3cf41076-8a34-4483-b2fd-385ee8e64f8d" /> |
