### PR TITLE
fix default icon color in ios dark mode

### DIFF
--- a/ios/ContextMenuView.m
+++ b/ios/ContextMenuView.m
@@ -187,10 +187,20 @@
     UIImage *iconImage = nil;
 
     if (action.icon != nil) {
-        UIColor *iconColor = [UIColor blackColor];
+        UIColor *iconColor;
 
         if (action.iconColor != nil) {
             iconColor = action.iconColor;
+        } else {
+            // Default color depends on dark mode
+            if (@available(iOS 13.0, *)) {
+                UIUserInterfaceStyle currentStyle = [UITraitCollection currentTraitCollection].userInterfaceStyle;
+                iconColor = (currentStyle == UIUserInterfaceStyleDark) ? [UIColor whiteColor] : [UIColor blackColor];
+            }
+            // Fallback for iOS < 13
+            else {
+                iconColor = [UIColor blackColor]; 
+            }
         }
         // Use custom icon from Assets.xcassets
         iconImage = [[UIImage imageNamed:action.icon] imageWithTintColor:iconColor];


### PR DESCRIPTION
Context menu action colors are black by default. When dark mode is enabled this makes the icons have bad constrast. This PRs add better default by using white color when dark mode is enabled.

# Before

<img width="276" alt="Screenshot 2025-03-10 at 10 04 23" src="https://github.com/user-attachments/assets/5bfee853-de0c-473f-9126-09cda2883939" />


# After
<img width="263" alt="Screenshot 2025-03-10 at 10 01 14" src="https://github.com/user-attachments/assets/29313a3b-b43b-4b42-bda8-86ea17cc351c" />
