### PR TITLE
feat(android): Add `fontName` prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ Optional. When set to `true`, the context menu is triggered with a single tap in
 
 Optional. Disable menu interaction.
 
+### `fontName`
+Optional, Android only. Custom font name to use for menu items. The font must be available in your app's font resources.
+
 ### `borderRadius`
 Optional, iOS only. Sets the border radius for all corners of the preview. Can be overridden by individual corner settings.
 

--- a/android/src/main/java/com/mpiannucci/reactnativecontextmenu/ContextMenuManager.java
+++ b/android/src/main/java/com/mpiannucci/reactnativecontextmenu/ContextMenuManager.java
@@ -50,6 +50,11 @@ public class ContextMenuManager extends ViewGroupManager<ContextMenuView> {
         view.setDisabled(disabled);
     }
 
+    @ReactProp(name = "fontName")
+    public void setFontName(ContextMenuView view, @Nullable String fontName) {
+        view.setFontName(fontName);
+    }
+
     @androidx.annotation.Nullable
     @Override
     public Map<String, Object> getExportedCustomDirectEventTypeConstants() {

--- a/index.d.ts
+++ b/index.d.ts
@@ -120,6 +120,10 @@ export interface ContextMenuProps extends ViewProps {
    * Disable shadow in preview
    */
   disableShadow?: boolean;
+  /**
+   * Custom font name to use for menu items (Android only). The font must be available in your app's font resources.
+   */
+  fontName?: string;
 }
 
 export default class ContextMenu extends Component<ContextMenuProps> { }


### PR DESCRIPTION
**Android only**
* This PR allows to set a `fontName` prop and change the font family of the context menu items