### PR TITLE
fix: iconColor

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -12,6 +12,10 @@ export interface ContextMenuAction {
    */
   title: string;
   /**
+   * Color of the title (default: black).
+   */
+  titleColor?: string;
+  /**
    * The subtitle of the action. iOS 15+.
    */
   subtitle?: string;
@@ -126,4 +130,4 @@ export interface ContextMenuProps extends ViewProps {
   fontName?: string;
 }
 
-export default class ContextMenu extends Component<ContextMenuProps> { }
+export default class ContextMenu extends Component<ContextMenuProps> {}

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ const ContextMenu = (props) => {
   const colorConvertedActions = props?.actions?.map((action) => ({
     ...action,
     iconColor: Platform.OS === 'ios' && action.iconColor ? processColor(action.iconColor) : action.iconColor,
+    titleColor: Platform.OS === 'ios' && action.titleColor ? processColor(action.titleColor) : action.titleColor,
   }));
 
   return (

--- a/index.js
+++ b/index.js
@@ -12,14 +12,13 @@ const ContextMenu = (props) => {
     borderBottomLeftRadius: -1
   };
 
-  const iconColor = props?.iconColor
-    ? Platform.OS === 'ios'
-      ? processColor(props.iconColor)
-      : props.iconColor
-    : undefined;
+  const colorConvertedActions = props?.actions?.map((action) => ({
+    ...action,
+    iconColor: Platform.OS === 'ios' && action.iconColor ? processColor(action.iconColor) : action.iconColor,
+  }));
 
   return (
-    <NativeContextMenu {...defaultProps} {...props} iconColor={iconColor}>
+    <NativeContextMenu {...defaultProps} {...props} actions={colorConvertedActions}>
       {props.children}
       {props.preview != null && Platform.OS === 'ios' ? (
         <View style={styles.preview} nativeID="ContextMenuPreview">{props.preview}</View>

--- a/ios/ContextMenuAction.h
+++ b/ios/ContextMenuAction.h
@@ -11,6 +11,7 @@
 @interface ContextMenuAction : NSObject
 
 @property (nonnull, nonatomic, copy) NSString* title;
+@property (nullable, nonatomic, copy) UIColor *titleColor;
 @property (nonnull, nonatomic, copy) NSString* subtitle;
 @property (nullable, nonatomic, copy) NSString* systemIcon;
 @property (nullable, nonatomic, copy) NSString* icon;

--- a/ios/ContextMenuView.m
+++ b/ios/ContextMenuView.m
@@ -208,7 +208,20 @@
         // Use system icon from SF Symbols
         iconImage = [UIImage systemImageNamed:action.systemIcon];
     }
-    
+
+    UIColor *titleColor = nil;
+    if (action.titleColor != nil) {
+        titleColor = action.titleColor;
+    } else {
+        // Default title color depends on dark mode
+        if (@available(iOS 13.0, *)) {
+            UIUserInterfaceStyle currentStyle = [UITraitCollection currentTraitCollection].userInterfaceStyle;
+            titleColor = (currentStyle == UIUserInterfaceStyleDark) ? [UIColor whiteColor] : [UIColor blackColor];
+        } else {
+            titleColor = [UIColor blackColor];
+        }
+    }
+
     if (action.actions != nil && action.actions.count > 0) {
       NSMutableArray<UIMenuElement*> *children = [[NSMutableArray alloc] init];
       [action.actions enumerateObjectsUsingBlock:^(ContextMenuAction * _Nonnull childAction, NSUInteger childIdx, BOOL * _Nonnull stop) {
@@ -255,7 +268,14 @@
         (action.disabled ? UIMenuElementAttributesDisabled : 0);
 
       actionMenuItem.state = 
-      	action.selected ? UIMenuElementStateOn : UIMenuElementStateOff;
+          action.selected ? UIMenuElementStateOn : UIMenuElementStateOff;
+
+      // Apply titleColor using attributedTitle
+      if (titleColor != nil) {
+          NSDictionary *attributes = @{NSForegroundColorAttributeName: titleColor};
+          NSAttributedString *attributedTitle = [[NSAttributedString alloc] initWithString:action.title attributes:attributes];
+          [actionMenuItem setValue:attributedTitle forKey:@"attributedTitle"];
+      }
 
       menuElement = actionMenuItem;
     }

--- a/ios/RCTConvert+ContextMenuAction.m
+++ b/ios/RCTConvert+ContextMenuAction.m
@@ -14,6 +14,7 @@
     json = [self NSDictionary:json];
     ContextMenuAction* action = [[ContextMenuAction alloc] init];
     action.title = [self NSString:json[@"title"]];
+    action.titleColor = json[@"titleColor"] ? [RCTConvert UIColor:json[@"titleColor"]] : nil;
     action.subtitle = [self NSString:json[@"subtitle"]];
     action.systemIcon = [self NSString:json[@"systemIcon"]];
     action.icon = [self NSString:json[@"icon"]];


### PR DESCRIPTION
This PR resolves issue https://github.com/mpiannucci/react-native-context-menu-view/issues/149
With this change iconColor is correctly parsed as property of an action.

Tested successfully on;

- [x] iOS
- [x] Android
