### PR TITLE
fix: Replace jcenter() with mavenCentral() in build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,7 +23,7 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
-            jcenter()
+            mavenCentral()
         }
         dependencies {
             classpath 'com.android.tools.build:gradle:3.4.1'
@@ -72,7 +72,7 @@ repositories {
         url "$rootDir/../node_modules/jsc-android/dist"
     }
     google()
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {
@@ -134,7 +134,7 @@ afterEvaluate { project ->
         def javaCompileTask = variant.javaCompileProvider.get()
 
         task "jar${name}"(type: Jar, dependsOn: javaCompileTask) {
-            from javaCompileTask.destinationDir
+            from javaCompileTask.destinationDirectory.get().asFile
         }
     }
 


### PR DESCRIPTION
fixes #167 

As temporary workaround you can install my fork by setting this in package.json:

"react-native-context-menu-view": "jasperaelvoet/react-native-context-menu-view",