### PR TITLE
Update docs in regards to `destructive` only working on iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ const Example = () => {
       actions={[{ title: "Title 1" }, { title: "Title 2" }]}
       onPress={(e) => {
         console.warn(
-          `Pressed ${e.nativeEvent.name} at index ${e.nativeEvent.index}`
+          `Pressed ${e.nativeEvent.name} at index ${e.nativeEvent.index}`,
         );
       }}
     >
@@ -60,7 +60,7 @@ Array of `{ title: string, subtitle?: string, systemIcon?: string, icon?: string
 
 - `iconColor` will change the color of the icon provided to the `icon` prop and has no effect on `systemIcon` (default: black)
 
-- `destructive` items are rendered in red (iOS only, default: false)
+- `destructive` items are rendered in red (default: false)
 
 - `selected` items have a checkmark next to them (iOS only, default: false)
 
@@ -97,22 +97,29 @@ Optional. When set to `true`, the context menu is triggered with a single tap in
 Optional. Disable menu interaction.
 
 ### `fontName`
+
 Optional, Android only. Custom font name to use for menu items. The font must be available in your app's font resources.
 
 ### `borderRadius`
+
 Optional, iOS only. Sets the border radius for all corners of the preview. Can be overridden by individual corner settings.
 
 ### `borderTopLeftRadius`
+
 Optional, iOS only. Sets the border radius specifically for the top left corner of the preview.
 
 ### `borderTopRightRadius`
+
 Optional, iOS only. Sets the border radius specifically for the top right corner of the preview.
 
 ### `borderBottomRightRadius`
+
 Optional, iOS only. Sets the border radius specifically for the bottom right corner of the preview.
 
 ### `borderBottomLeftRadius`
+
 Optional, iOS only. Sets the border radius specifically for the bottom left corner of the preview.
 
 ### `disableShadow`
+
 Optional, iOS only. When set to `true`, removes the shadow from the preview. Default is `false`.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ const Example = () => {
       actions={[{ title: "Title 1" }, { title: "Title 2" }]}
       onPress={(e) => {
         console.warn(
-          `Pressed ${e.nativeEvent.name} at index ${e.nativeEvent.index}`,
+          `Pressed ${e.nativeEvent.name} at index ${e.nativeEvent.index}`
         );
       }}
     >
@@ -97,29 +97,22 @@ Optional. When set to `true`, the context menu is triggered with a single tap in
 Optional. Disable menu interaction.
 
 ### `fontName`
-
 Optional, Android only. Custom font name to use for menu items. The font must be available in your app's font resources.
 
 ### `borderRadius`
-
 Optional, iOS only. Sets the border radius for all corners of the preview. Can be overridden by individual corner settings.
 
 ### `borderTopLeftRadius`
-
 Optional, iOS only. Sets the border radius specifically for the top left corner of the preview.
 
 ### `borderTopRightRadius`
-
 Optional, iOS only. Sets the border radius specifically for the top right corner of the preview.
 
 ### `borderBottomRightRadius`
-
 Optional, iOS only. Sets the border radius specifically for the bottom right corner of the preview.
 
 ### `borderBottomLeftRadius`
-
 Optional, iOS only. Sets the border radius specifically for the bottom left corner of the preview.
 
 ### `disableShadow`
-
 Optional, iOS only. When set to `true`, removes the shadow from the preview. Default is `false`.

--- a/index.d.ts
+++ b/index.d.ts
@@ -32,7 +32,7 @@ export interface ContextMenuAction {
    */
   iconColor?: string;
   /**
-   * Destructive items are rendered in red on iOS, and unchanged on Android. (default: false)
+   * Destructive items are rendered in red. (default: false)
    */
   destructive?: boolean;
   /**


### PR DESCRIPTION
Support for destructive menu items on Android was added back in October 2023 (#98) - All of the references in the codebase state it is iOS only.

This PR is to remove any mention of destructive only working on iOS.